### PR TITLE
Adding hyphen to string match

### DIFF
--- a/mod_muc_focus.lua
+++ b/mod_muc_focus.lua
@@ -988,7 +988,7 @@ module:hook("iq/bare", function (event)
                     -- note those and add the msid to the participants presence
                     for parameter in source:childtags("parameter", xmlns_jingle_rtp_ssma) do
                         if parameter.attr.name == "msid" then
-                            local msid = string.match(parameter.attr.value, "[a-zA-Z0-9]+") -- FIXME: token-char
+                            local msid = string.match(parameter.attr.value, "[a-zA-Z0-9%-]+") -- FIXME: token-char
                             -- second part is the track
                             module:log("debug", "msid %s content %s action %s", msid, content.attr.name, action)
                             if action == "session-accept" or action == "source-add" then
@@ -1098,7 +1098,7 @@ module:hook("iq/bare", function (event)
                 participant2sources[room.jid][sender.nick][name] = new_sources_of_name;
                 module:log("debug", "participant2sources %s now of size %d", name, #new_sources_of_name)
               end --End for name, sourcelist
-            end --End else           
+            end --End else
 
             -- sent to everyone but the sender
             if sessions[room.jid] then


### PR DESCRIPTION
In our application we've started using streams that are created from the tracks of other streams. It seems that Chrome creates these streams with ids including hyphens. 

Example id: 
`59755c78-92f8-4634-85a4-ef784de712f9`

Currently, only the first part of the id will be matched ("59755c78" in this example). This PR adds the hyphen character to the pattern so that the full id is matched.