### PR TITLE
Adding count of sources added or removed

### DIFF
--- a/mod_muc_focus.lua
+++ b/mod_muc_focus.lua
@@ -1047,13 +1047,19 @@ module:hook("iq/bare", function (event)
             if action == "source-remove" then
                 sendaction = "source-remove"
             end
+
             local sourceadd = st.iq({ from = room.jid, type = "set" })
                 :tag("jingle", { xmlns = xmlns_jingle, action = sendaction, initiator = room.jid, sid = sid })
+
+            -- Count of sources added or removed
+            local sourcesaddedorremoved = 0
+
             for name, sourcelist in pairs(sources) do
                 sourceadd:tag("content", { creator = "initiator", name = name, senders = "both" })
                     :tag("description", { xmlns = xmlns_jingle_rtp, media = name })
                     for i, source in ipairs(sourcelist) do
                         sourceadd:add_child(source)
+                        sourcesaddedorremoved = sourcesaddedorremoved + 1
                     end
 
                     sourceadd:up() -- description
@@ -1098,10 +1104,10 @@ module:hook("iq/bare", function (event)
                 participant2sources[room.jid][sender.nick][name] = new_sources_of_name;
                 module:log("debug", "participant2sources %s now of size %d", name, #new_sources_of_name)
               end --End for name, sourcelist
-            end --End else           
+            end --End else
 
             -- sent to everyone but the sender
-            if sessions[room.jid] then
+            if sessions[room.jid] and sourcesaddedorremoved > 0 then
                 for occupant_jid in iterators.keys(participant2sources[room.jid]) do
                     if occupant_jid ~= sender.nick and sessions[room.jid][occupant_jid] then
                         module:log("debug", "send %s to %s", sendaction, tostring(occupant_jid))


### PR DESCRIPTION
We've recently started having all clients initially session-accept with no streams, and then add streams after the session is established (this helped cut down on some weird SLD errors we were seeing when receiving source-adds while trying to SLD).

Currently, a session-accept with no sources results in a source-add being sent to all participants whether or not any sources are actually added. Unless clients are checking for source adds with no sources, this "empty" source add will likely result in a SRD -> SLD workflow. This created an opportunity for similar problems that I initially described with in-progress SLD errors when sessions initiate.

This PR adds a count of sources added (or removed, although that would probably indicate some odd behavior on the client-side if you're sending source-removes with no sources) so that session-accepts (or source-adds or source-removes) with no streams do not result in messages sent to other clients in a room.
